### PR TITLE
💄 Sidebar + color scheme change

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -9,7 +9,7 @@ export default function Layout({ children }) {
 
 				<Sidebar />
 
-				<main className="mt-20 grow lg:mt-0">{children}</main>
+				<main className="mt-24 grow lg:mt-0">{children}</main>
 			</div>
 		</>
 	);

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,53 +1,16 @@
-import Link from "next/link";
-import ThemeSwitch from "./ThemeSwitch.js";
-import { social, blogSource, navLinks, name } from "../metadata.js";
-import MobileNav from "./MobileNav.js";
+import Navbar from "./Navbar";
+import Sidebar from "./Sidebar";
 
 export default function Layout({ children }) {
 	return (
 		<>
-			<nav className="relative z-50 flex items-center justify-between py-8">
-				<Link href="/">
-					<h1 className="text-2xl font-bold transition-colors hover:text-neutral-600 dark:hover:text-neutral-400 max-[380px]:text-xl md:text-3xl">
-						{name}
-					</h1>
-				</Link>
-				<span className="hidden print:block">nchristopher.me</span>
-				<div className="flex print:hidden">
-					{Object.entries(navLinks).map(([title, href]) => (
-						<Link
-							key={href}
-							href={href}
-							className="hidden px-6 text-lg font-medium transition-colors hover:text-neutral-600 dark:hover:text-neutral-400 md:block md:text-xl"
-						>
-							{title}
-						</Link>
-					))}
+			<div className="mb-8 gap-8 lg:my-20 lg:flex lg:flex-row">
+				<Navbar />
 
-					<ThemeSwitch />
-					<MobileNav />
-				</div>
-			</nav>
+				<Sidebar />
 
-			<main>{children}</main>
-
-			<footer className="mt-16 flex items-center justify-between border-t-2 border-neutral-300 py-4 text-neutral-700 dark:border-neutral-700 dark:text-neutral-300">
-				<a href={blogSource} className="">
-					&copy; 2023 {name}
-				</a>
-
-				<div className="print:hidden">
-					{social.map((item) => (
-						<a
-							href={item.href}
-							key={item.href}
-							className="inline-block px-2 transition-transform ease-in-out hover:scale-110"
-						>
-							<item.Icon aria-label={item.label} />
-						</a>
-					))}
-				</div>
-			</footer>
+				<main className="mt-20 grow lg:mt-0">{children}</main>
+			</div>
 		</>
 	);
 }

--- a/components/Menu.js
+++ b/components/Menu.js
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { useEffect } from "react";
 import { navLinks, social } from "../metadata";
 
-export default function MobileNav() {
+export default function Menu() {
 	function handleLinkClick() {
 		document.getElementById("nav").checked = false;
 		document.body.style.overflow = "auto";

--- a/components/MobileNav.js
+++ b/components/MobileNav.js
@@ -1,7 +1,7 @@
 import { IconMenu, IconX } from "@tabler/icons-react";
 import Link from "next/link";
 import { useEffect } from "react";
-import { navLinks } from "../metadata";
+import { navLinks, social } from "../metadata";
 
 export default function MobileNav() {
 	function handleLinkClick() {
@@ -12,7 +12,6 @@ export default function MobileNav() {
 	function handleStateChange(e) {
 		if (e.target.checked) {
 			document.body.style.overflow = "hidden";
-			window.scrollTo(0, 0);
 		} else {
 			document.body.style.overflow = "auto";
 		}
@@ -21,7 +20,7 @@ export default function MobileNav() {
 	// Close mobile nav when window is resized to desktop
 	useEffect(() => {
 		function handleResize() {
-			if (window.innerWidth >= 768) {
+			if (window.innerWidth >= 1024) {
 				document.getElementById("nav").checked = false;
 				document.body.style.overflow = "auto";
 			}
@@ -34,42 +33,50 @@ export default function MobileNav() {
 
 	return (
 		<>
-			<label htmlFor="nav" className="sr-only md:hidden">
+			<label htmlFor="nav" className="sr-only lg:hidden">
 				Toggle navigation
 			</label>
 			<input
 				type="checkbox"
 				id="nav"
-				className="peer sr-only md:hidden"
+				className="peer sr-only lg:hidden"
 				onChange={handleStateChange}
 			/>
 
 			<label
 				htmlFor="nav"
-				className="pl-2 transition-colors hover:cursor-pointer hover:text-neutral-600 peer-focus-visible:[outline:auto] dark:hover:text-neutral-400 md:hidden"
+				className="flex items-center rounded-md p-2 transition-colors hover:cursor-pointer hover:bg-slate-300/50 peer-focus-visible:[outline:auto] dark:hover:bg-slate-700/50 lg:mx-auto lg:hidden"
 			>
 				<IconMenu
 					className="[#nav:checked_~_label_&]:hidden"
 					size={24}
 				/>
 				<IconX
-					className="hidden [#nav:checked_~_label_&]:block"
+					className="hidden [#nav:checked_~_label_&]:inline"
 					size={24}
 				/>
 			</label>
-			<div className="pointer-events-none fixed left-0 top-0 -z-10 h-full w-full bg-white/50 opacity-0 backdrop-blur-lg transition ease-in-out peer-checked:pointer-events-auto peer-checked:opacity-100 dark:bg-black/50 md:!hidden">
-				<div className="flex flex-col divide-y divide-neutral-300 p-6 pt-20 text-2xl font-semibold dark:divide-neutral-700">
-					{Object.entries(navLinks).map(([title, href]) => (
+			<div className="pointer-events-none absolute left-0 top-0 -z-10 h-screen w-screen bg-white/50 opacity-0 backdrop-blur-lg transition ease-in-out peer-checked:pointer-events-auto peer-checked:opacity-100 dark:bg-black/50 lg:!hidden">
+				<div className="flex flex-col divide-y divide-slate-400/50 p-6 pt-20 text-2xl font-semibold dark:divide-slate-600/50">
+					{navLinks.map(({ title, href }) => (
 						<Link
 							key={href}
 							href={href}
 							className="group -translate-x-80 py-4 duration-300 [#nav:checked_~_div_&]:translate-x-0 [#nav:checked_~_div_&]:transition [&:nth-child(2)]:delay-75 [&:nth-child(3)]:delay-150"
 							onClick={handleLinkClick}
 						>
-							<div className="transition ease-in-out group-hover:text-neutral-600 dark:group-hover:text-neutral-400">
+							<div className="transition ease-in-out group-hover:text-slate-600 dark:group-hover:text-slate-400">
 								{title}
 							</div>
 						</Link>
+					))}
+				</div>
+
+				<div className="fixed bottom-20 flex w-full flex-row justify-center gap-8">
+					{social.map(({ href, Icon }) => (
+						<a href={href} key={href}>
+							<Icon size={28} />
+						</a>
 					))}
 				</div>
 			</div>

--- a/components/MobileNav.js
+++ b/components/MobileNav.js
@@ -72,9 +72,13 @@ export default function MobileNav() {
 					))}
 				</div>
 
-				<div className="fixed bottom-20 flex w-full flex-row justify-center gap-8">
+				<div className="fixed bottom-32 flex w-full flex-row justify-center gap-8">
 					{social.map(({ href, Icon }) => (
-						<a href={href} key={href}>
+						<a
+							href={href}
+							key={href}
+							className="rounded-md p-2 transition ease-in-out hover:bg-slate-300/50 dark:hover:bg-slate-700/50"
+						>
 							<Icon size={28} />
 						</a>
 					))}

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,0 +1,18 @@
+import { name } from "../metadata";
+import MobileNav from "./MobileNav";
+import ThemeSwitch from "./ThemeSwitch";
+import Link from "next/link";
+
+export default function Navbar() {
+	return (
+		<nav className="fixed left-0 top-0 z-50 flex w-full items-center justify-between rounded-b-2xl bg-slate-50/70 px-6 py-4 backdrop-blur-lg dark:bg-slate-950/70 lg:hidden">
+			<MobileNav />
+
+			<Link className="text-3xl font-semibold" href="/">
+				{name}
+			</Link>
+
+			<ThemeSwitch />
+		</nav>
+	);
+}

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 export default function Navbar() {
 	return (
-		<nav className="fixed left-0 top-0 z-50 flex w-full items-center justify-between rounded-b-2xl bg-slate-50/70 px-6 py-4 backdrop-blur-lg dark:bg-slate-950/70 lg:hidden">
+		<nav className="fixed left-0 top-0 z-50 flex w-full items-center justify-between rounded-b-2xl bg-slate-50/70 px-6 py-4 backdrop-blur-lg ease-in-out dark:bg-slate-950/70 lg:hidden [&:has(#nav:checked)]:backdrop-filter-none [&:has(#nav:checked)]:transition">
 			<MobileNav />
 
 			<Link className="text-3xl font-semibold" href="/">

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,12 +1,12 @@
 import { name } from "../metadata";
-import MobileNav from "./MobileNav";
+import Menu from "./Menu";
 import ThemeSwitch from "./ThemeSwitch";
 import Link from "next/link";
 
 export default function Navbar() {
 	return (
 		<nav className="fixed left-0 top-0 z-50 flex w-full items-center justify-between rounded-b-2xl bg-slate-50/70 px-6 py-4 backdrop-blur-lg ease-in-out dark:bg-slate-950/70 lg:hidden [&:has(#nav:checked)]:backdrop-filter-none [&:has(#nav:checked)]:transition">
-			<MobileNav />
+			<Menu />
 
 			<Link className="text-3xl font-semibold" href="/">
 				{name}

--- a/components/NewsletterForm.js
+++ b/components/NewsletterForm.js
@@ -52,7 +52,7 @@ export default function NewsletterForm({
 	};
 
 	return (
-		<div className="mx-auto max-w-lg rounded-lg bg-neutral-100 p-4 dark:bg-neutral-900 print:hidden md:text-lg">
+		<div className="mx-auto max-w-lg rounded-lg bg-slate-100 p-4 dark:bg-slate-900 print:hidden md:text-lg">
 			<span
 				className={clsx(
 					{ "text-red-600 dark:text-red-400": error },
@@ -70,7 +70,7 @@ export default function NewsletterForm({
 				onSubmit={subscribe}
 			>
 				<input
-					className="grow rounded-md bg-white px-4 py-2 dark:bg-black "
+					className="grow rounded-md bg-slate-50 px-4 py-2 dark:bg-slate-950"
 					type="email"
 					id="email"
 					name="email"

--- a/components/NewsletterForm.js
+++ b/components/NewsletterForm.js
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { IconLoader2, IconNews } from "@tabler/icons-react";
+import { IconLoader2, IconMail } from "@tabler/icons-react";
 import clsx from "clsx";
 
 const formId = process.env.NEXT_PUBLIC_LOOPS_FORM_ID;
@@ -15,9 +15,9 @@ export default function NewsletterForm({
 	const error = state === "error";
 
 	const icon = loading ? (
-		<IconLoader2 className="inline-block animate-spin" />
+		<IconLoader2 className="animate-spin" />
 	) : (
-		<IconNews className="inline-block" />
+		<IconMail className="" />
 	);
 
 	const subscribe = async (e) => {
@@ -52,7 +52,7 @@ export default function NewsletterForm({
 	};
 
 	return (
-		<div className="mx-auto max-w-lg rounded-lg bg-slate-100 p-4 dark:bg-slate-900 print:hidden md:text-lg">
+		<div className="mx-auto max-w-lg rounded-lg border border-slate-200 bg-neutral-100/50 p-4 dark:border-slate-800 dark:bg-neutral-900/50 print:hidden md:text-lg">
 			<span
 				className={clsx(
 					{ "text-red-600 dark:text-red-400": error },
@@ -80,7 +80,7 @@ export default function NewsletterForm({
 				/>
 
 				<button
-					className="grow rounded-md bg-emerald-300 px-4 py-2 transition ease-in-out hover:bg-emerald-200 dark:bg-emerald-700 dark:hover:bg-emerald-800"
+					className="flex grow items-center justify-center gap-1 rounded-md bg-emerald-300 px-4 py-2 transition ease-in-out hover:bg-emerald-200 dark:bg-emerald-700 dark:hover:bg-emerald-800"
 					disabled={loading}
 					type="submit"
 				>

--- a/components/PostCard.js
+++ b/components/PostCard.js
@@ -37,7 +37,7 @@ export default function PostCard({
 				</h1>
 			</div>
 
-			<div className="absolute left-4 bottom-4 rounded-lg bg-neutral-600/30 px-4 py-2 text-sm backdrop-blur transition hover:bg-neutral-600/60 md:text-base">
+			<div className="absolute bottom-4 left-4 rounded-lg bg-slate-600/30 px-4 py-2 text-sm backdrop-blur transition hover:bg-slate-600/60 md:text-base">
 				Read post
 			</div>
 		</Link>

--- a/components/ProjectCard.js
+++ b/components/ProjectCard.js
@@ -10,7 +10,7 @@ export default function ProjectCard({
 	noCrop,
 }) {
 	return (
-		<div className="flex flex-col overflow-hidden rounded-xl border border-neutral-200 bg-neutral-100/50 transition-transform ease-in-out hover:scale-[1.01] dark:border-neutral-800 dark:bg-neutral-900/50">
+		<div className="flex flex-col overflow-hidden rounded-xl border border-slate-200 bg-neutral-100/30 transition-transform ease-in-out hover:scale-[1.01] dark:border-slate-800 dark:bg-neutral-900/30">
 			{cover && (
 				<div className="relative h-48">
 					<Image
@@ -30,7 +30,7 @@ export default function ProjectCard({
 					{Object.entries(links).map(([title, href]) => (
 						<a key={href} href={href} className="group">
 							{title}{" "}
-							<IconArrowUpRight className="inline-block transition ease-in-out group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+							<IconArrowUpRight className="inline-block transition ease-in-out group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
 						</a>
 					))}
 				</div>

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import ThemeSwitch from "./ThemeSwitch";
+import { social, name, navLinks } from "../metadata.js";
+import { useRouter } from "next/router.js";
+import clsx from "clsx";
+
+function SidebarLink({ title, href, Icon }) {
+	let { pathname } = useRouter();
+	if (pathname.startsWith("/blog")) pathname = "/blog";
+	const active = pathname === href;
+
+	return (
+		<Link
+			key={href}
+			href={href}
+			className="group w-56 py-1 text-2xl font-semibold"
+		>
+			<div
+				className={clsx(
+					"flex items-center gap-4 rounded-lg px-4 py-2 transition-colors ease-in-out",
+					{
+						"bg-slate-300/70 dark:bg-slate-700/70": active,
+						"group-hover:bg-slate-300/50 dark:group-hover:bg-slate-700/50":
+							!active,
+					}
+				)}
+			>
+				<Icon size={32} className="inline-block align-middle" />
+				{title}
+			</div>
+		</Link>
+	);
+}
+
+export default function Sidebar() {
+	return (
+		<nav className="z-50 hidden flex-shrink-0 lg:block lg:w-72">
+			<div className="sticky top-20 flex flex-col">
+				<div className="flex flex-row items-center">
+					<Link className="align-middle text-4xl font-bold" href="/">
+						{name}
+					</Link>
+
+					<ThemeSwitch />
+				</div>
+
+				<div className="mt-6 flex flex-col">
+					{navLinks.map((data) => (
+						<SidebarLink {...data} key={data.href} />
+					))}
+				</div>
+
+				<div className="fixed bottom-20 flex w-72 flex-row justify-center gap-6">
+					{social.map(({ href, Icon }) => (
+						<a href={href} key={href}>
+							<Icon size={28} />
+						</a>
+					))}
+				</div>
+			</div>
+		</nav>
+	);
+}

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -52,7 +52,11 @@ export default function Sidebar() {
 
 				<div className="fixed bottom-20 flex w-72 flex-row justify-center gap-6">
 					{social.map(({ href, Icon }) => (
-						<a href={href} key={href}>
+						<a
+							href={href}
+							key={href}
+							className="rounded-md p-2 transition ease-in-out hover:bg-slate-300/50 dark:hover:bg-slate-700/50"
+						>
 							<Icon size={28} />
 						</a>
 					))}

--- a/components/ThemeSwitch.js
+++ b/components/ThemeSwitch.js
@@ -18,7 +18,7 @@ export default function ThemeSwitch() {
 		<button
 			aria-label="Switch themes"
 			onClick={toggleTheme}
-			className="noscript-hidden px-2 transition-colors hover:text-neutral-600 dark:hover:text-neutral-400 md:pr-0"
+			className="noscript-hidden flex items-center rounded-md p-2 transition-colors hover:bg-slate-300/50 dark:hover:bg-slate-700/50 lg:mx-auto"
 		>
 			<Icon size={24} />
 		</button>

--- a/metadata.js
+++ b/metadata.js
@@ -2,6 +2,9 @@ import {
 	IconMail,
 	IconBrandGithub,
 	IconBrandTwitter,
+	IconNotebook,
+	IconCode,
+	IconHome,
 } from "@tabler/icons-react";
 
 export const name = "Nick Oates";
@@ -11,11 +14,11 @@ export const blogSource = github + "/blog";
 
 export const email = "nick@nickoates.com";
 
-export const navLinks = {
-	Home: "/",
-	Projects: "/projects",
-	Blog: "/blog",
-};
+export const navLinks = [
+	{ title: "Home", href: "/", Icon: IconHome },
+	{ title: "Projects", href: "/projects", Icon: IconCode },
+	{ title: "Blog", href: "/blog", Icon: IconNotebook },
+];
 
 export const social = [
 	{

--- a/metadata.js
+++ b/metadata.js
@@ -22,9 +22,9 @@ export const navLinks = [
 
 export const social = [
 	{
-		Icon: IconMail,
-		label: `Email ${name}`,
-		href: `mailto:${email}`,
+		Icon: IconBrandTwitter,
+		label: `Visit ${name} on Twitter`,
+		href: "https://twitter.com/nickoates_",
 	},
 	{
 		Icon: IconBrandGithub,
@@ -32,9 +32,9 @@ export const social = [
 		href: github,
 	},
 	{
-		Icon: IconBrandTwitter,
-		label: `Visit ${name} on Twitter`,
-		href: "https://twitter.com/nickoates_",
+		Icon: IconMail,
+		label: `Email ${name}`,
+		href: `mailto:${email}`,
 	},
 ];
 

--- a/pages/404.js
+++ b/pages/404.js
@@ -10,7 +10,7 @@ export default function NotFound() {
 			</h1>
 			<p>To make up for it, here&apos;s a picture of a cat.</p>
 
-			<div className="relative mx-auto mt-6 w-fit overflow-hidden rounded-md bg-neutral-200 shadow-md dark:bg-neutral-800">
+			<div className="relative mx-auto mt-6 w-fit overflow-hidden rounded-md bg-slate-200 shadow-md dark:bg-slate-800">
 				<IconLoader2
 					className="absolute inset-0 m-auto animate-spin"
 					size={48}
@@ -29,7 +29,7 @@ export default function NotFound() {
 			<div className="mt-8 text-center">
 				<Link
 					href="/"
-					className="rounded-md bg-blue-400 py-4 px-6 transition ease-in-out hover:bg-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700"
+					className="rounded-md bg-blue-400 px-6 py-4 transition ease-in-out hover:bg-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700"
 				>
 					Go home <IconArrowRight className="inline-block" />
 				</Link>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -4,7 +4,7 @@ export default function Document() {
 	return (
 		<Html className="scroll-smooth" lang="en">
 			<Head />
-			<body className="mx-auto max-w-4xl bg-white px-6 text-black dark:bg-black dark:text-white xl:px-0">
+			<body className="max-w-7xl bg-slate-50 px-6 text-black dark:bg-slate-950 dark:text-white lg:mx-auto 2xl:px-0">
 				<Main />
 				<NextScript />
 			</body>

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -24,7 +24,7 @@ export default function Post({ post }) {
 	const MDXContent = useMDXComponent(post.body.code);
 
 	return (
-		<article className="prose prose-lg prose-neutral mx-auto prose-a:text-blue-500 prose-a:decoration-2 prose-a:transition-colors prose-a:ease-in-out hover:prose-a:text-blue-400 prose-pre:bg-neutral-900 dark:prose-invert dark:hover:prose-a:text-blue-600 md:prose-xl lg:prose-2xl">
+		<article className="prose prose-lg prose-slate mx-auto dark:prose-invert md:prose-xl lg:prose-2xl prose-a:text-blue-500 prose-a:decoration-2 prose-a:transition-colors prose-a:ease-in-out hover:prose-a:text-blue-400 prose-pre:bg-slate-900 dark:hover:prose-a:text-blue-600">
 			<div className="md:text-center">
 				<time dateTime={post.date}>{post.formattedDate}</time> &bull;{" "}
 				{post.readingTime} min read

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -23,12 +23,12 @@ export default function Blog({ posts }) {
 					<input
 						type="text"
 						name="search"
-						className="w-full rounded-md border border-neutral-200 py-2 px-4 drop-shadow dark:border-neutral-800 dark:bg-neutral-900"
+						className="w-full rounded-md border border-slate-200 px-4 py-2 drop-shadow dark:border-slate-800 dark:bg-slate-900"
 						placeholder="Search posts..."
 						aria-label="Search posts"
 						onChange={(e) => setSearchTerm(e.target.value)}
 					/>
-					<IconSearch className="absolute top-2 right-4" />
+					<IconSearch className="absolute right-4 top-2" />
 				</div>
 			</div>
 
@@ -41,7 +41,7 @@ export default function Blog({ posts }) {
 					key={post._raw.flattenedPath}
 					className="flex flex-col justify-between gap-1 py-4 transition-transform duration-300 ease-in-out hover:scale-105 lg:flex-row"
 				>
-					<div className="text-neutral-600 dark:text-neutral-400 md:text-lg ">
+					<div className="text-slate-600 dark:text-slate-400 md:text-lg ">
 						<time
 							dateTime={post.date}
 							className="whitespace-pre after:content-['_•_'] lg:after:content-['\A']"
@@ -54,7 +54,7 @@ export default function Blog({ posts }) {
 						<h1 className="mb-1 text-xl font-bold md:text-2xl">
 							{post.title}
 						</h1>
-						<h2 className="text-lg text-neutral-600 dark:text-neutral-400 md:text-xl">
+						<h2 className="text-lg text-slate-600 dark:text-slate-400 md:text-xl">
 							{post.summary}
 						</h2>
 					</div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -60,7 +60,7 @@ export default function Home({ posts }) {
 
 				<Link
 					href="/blog"
-					className="group ml-8 transition-colors hover:text-neutral-600 dark:hover:text-neutral-400"
+					className="group ml-8 transition-colors hover:text-slate-600 dark:hover:text-slate-400"
 				>
 					View All{" "}
 					<IconArrowRight className="inline-block transition-transform ease-in-out group-hover:translate-x-0.5" />
@@ -79,7 +79,7 @@ export default function Home({ posts }) {
 			</OrbContainer>
 
 			<h2 className="my-4 text-2xl font-bold">Newsletter</h2>
-			<p className="my-4 mx-auto max-w-2xl text-xl">
+			<p className="mx-auto my-4 max-w-2xl text-xl">
 				Occasionally, I send out a newsletter to share my thoughts about
 				the latest tech news and other things I find interesting &mdash;
 				I won&apos;t spam you, promise!


### PR DESCRIPTION
This pull request moves the navbar to a sidebar on large screens, and changes the color scheme to `slate` from `neutral` (using `slate-50` instead of `white` and `slate-950` instead of `black`).

The navbar on small screens has also been redesigned. It's fixed to top of the screen, making it always visible. My name is now in the middle, with menu on left and theme switch on right.

- [x] Fix menu not having a blurred background on Chrome 
- [x] Add hover effect to social icons.
