### PR TITLE
Redesign homepage in Microsoft Windows 2000 style

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,49 +1,205 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Menu from "./Menu";
-import ThemeSwitch from "./ThemeSwitch";
 import Link from "next/link";
-import clsx from "clsx";
+import { links } from "@/lib/navData";
+import { usePathname } from "next/navigation";
 
 export default function Navbar() {
 	const [open, setOpen] = useState(false);
-	const [solid, setSolid] = useState(false);
+	const [time, setTime] = useState("");
+	const rawPathname = usePathname();
+	const pathname = rawPathname.startsWith("/blog") ? "/blog" : rawPathname;
 
 	useEffect(() => {
-		function handleScroll() {
-			if (window.scrollY >= 20) {
-				setSolid(true);
-			} else {
-				setSolid(false);
-			}
+		function updateTime() {
+			const now = new Date();
+			setTime(
+				now.toLocaleTimeString(undefined, {
+					hour: "2-digit",
+					minute: "2-digit",
+				}),
+			);
 		}
-
-		window.addEventListener("scroll", handleScroll);
-		return () => window.removeEventListener("scroll", handleScroll);
-	});
+		updateTime();
+		const id = setInterval(updateTime, 30000);
+		return () => clearInterval(id);
+	}, []);
 
 	return (
-		<nav
-			className={clsx(
-				"fixed top-0 left-0 z-50 flex w-full items-center justify-between px-4 py-2 before:absolute before:left-0 before:-z-10 before:h-full before:w-full before:rounded-b-2xl before:border-b before:bg-zinc-50/70 before:backdrop-blur-lg before:transition lg:hidden dark:before:bg-zinc-950/70",
-				{
-					"before:border-zinc-200/70 before:opacity-100 before:drop-shadow-lg dark:before:border-zinc-800/70":
-						solid,
-					"before:border-transparent before:opacity-0": !solid,
-				},
-			)}
-		>
-			<Menu open={open} setOpen={setOpen} />
-
-			<Link
-				className="text-3xl font-semibold transition-colors hover:text-zinc-600 dark:hover:text-zinc-400"
-				href="/"
+		<>
+			{/* Win2000 Taskbar */}
+			<nav
+				className="fixed top-0 left-0 z-50 w-full lg:hidden"
+				style={{
+					background: "#d4d0c8",
+					borderBottom: "2px solid #404040",
+					boxShadow: "0 2px 0 #808080",
+					display: "flex",
+					alignItems: "center",
+					padding: "2px 4px",
+					gap: "4px",
+				}}
 			>
-				Nick Oates
-			</Link>
+				{/* Start button */}
+				<button
+					type="button"
+					onClick={() => setOpen((v) => !v)}
+					aria-expanded={open}
+					aria-label="Open navigation menu"
+					style={{
+						display: "flex",
+						alignItems: "center",
+						gap: "4px",
+						padding: "2px 8px",
+						background: open ? "#808080" : "#d4d0c8",
+						borderTop: open ? "2px solid #404040" : "2px solid #ffffff",
+						borderLeft: open ? "2px solid #404040" : "2px solid #ffffff",
+						borderRight: open ? "2px solid #ffffff" : "2px solid #404040",
+						borderBottom: open ? "2px solid #ffffff" : "2px solid #404040",
+						boxShadow: open
+							? "inset 1px 1px 0 #808080, inset -1px -1px 0 #dfdfdf"
+							: "inset 1px 1px 0 #dfdfdf, inset -1px -1px 0 #808080",
+						fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+						fontSize: "11px",
+						fontWeight: "bold",
+						color: "#000",
+						cursor: "default",
+					}}
+				>
+					<span style={{ fontSize: "14px" }}>🪟</span>
+					Start
+				</button>
 
-			<ThemeSwitch />
-		</nav>
+				{/* Divider */}
+				<div style={{ width: "2px", height: "20px", background: "#808080", borderRight: "1px solid #fff" }} aria-hidden />
+
+				{/* Page title */}
+				<span
+					style={{
+						fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+						fontSize: "11px",
+						color: "#000",
+						flexGrow: 1,
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+						whiteSpace: "nowrap",
+					}}
+				>
+					Nick Oates — {links.find((l) => l.href === pathname)?.title ?? "Page"}
+				</span>
+
+				{/* System clock */}
+				<div
+					style={{
+						background: "#d4d0c8",
+						borderTop: "1px solid #808080",
+						borderLeft: "1px solid #808080",
+						borderRight: "1px solid #ffffff",
+						borderBottom: "1px solid #ffffff",
+						padding: "2px 6px",
+						fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+						fontSize: "11px",
+						color: "#000",
+					}}
+				>
+					{time}
+				</div>
+			</nav>
+
+			{/* Start Menu popup */}
+			{open && (
+				<div
+					className="fixed z-50 lg:hidden"
+					style={{
+						top: "32px",
+						left: "4px",
+						background: "#d4d0c8",
+						borderTop: "2px solid #ffffff",
+						borderLeft: "2px solid #ffffff",
+						borderRight: "2px solid #404040",
+						borderBottom: "2px solid #404040",
+						boxShadow: "2px 2px 8px rgba(0,0,0,0.5), inset 1px 1px 0 #dfdfdf, inset -1px -1px 0 #808080",
+						minWidth: "160px",
+					}}
+				>
+					{/* Start menu header */}
+					<div
+						style={{
+							background: "linear-gradient(to bottom, #0a246a, #3a5fa8)",
+							padding: "8px 6px",
+							writingMode: "vertical-rl",
+							transform: "rotate(180deg)",
+							fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+							fontSize: "14px",
+							fontWeight: "bold",
+							color: "#fff",
+							float: "left",
+							height: "100%",
+							minHeight: "140px",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "flex-end",
+							letterSpacing: "1px",
+						}}
+					>
+						Nick<span style={{ fontWeight: "normal", opacity: 0.8 }}>Oates</span>
+					</div>
+					<div style={{ marginLeft: "28px" }}>
+						{links.map((link) => {
+							const isActive = pathname === link.href;
+							return (
+								<Link
+									key={link.href}
+									href={link.href}
+									onClick={() => setOpen(false)}
+									style={{
+										display: "flex",
+										alignItems: "center",
+										gap: "8px",
+										padding: "5px 16px 5px 8px",
+										textDecoration: "none",
+										fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+										fontSize: "11px",
+										color: isActive ? "#fff" : "#000",
+										background: isActive ? "#0a246a" : "transparent",
+									}}
+									className={!isActive ? "hover:bg-[#0a246a] hover:text-white" : ""}
+								>
+									<link.Icon size={20} aria-hidden />
+									{link.title}
+								</Link>
+							);
+						})}
+						<div style={{ borderTop: "1px solid #808080", margin: "2px 0" }} aria-hidden />
+						<a
+							href="mailto:nick@nickoates.com"
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: "8px",
+								padding: "5px 16px 5px 8px",
+								textDecoration: "none",
+								fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+								fontSize: "11px",
+								color: "#000",
+							}}
+							className="hover:bg-[#0a246a] hover:text-white"
+						>
+							✉ Contact
+						</a>
+					</div>
+				</div>
+			)}
+
+			{/* Backdrop to close menu */}
+			{open && (
+				<div
+					className="fixed inset-0 z-40 lg:hidden"
+					onClick={() => setOpen(false)}
+					aria-hidden
+				/>
+			)}
+		</>
 	);
 }

--- a/app/components/NewsletterForm.tsx
+++ b/app/components/NewsletterForm.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { IconLoader2, IconMail } from "@tabler/icons-react";
-import clsx from "clsx";
 import { subscribe, type State } from "@/lib/actions";
 import { useActionState } from "react";
-import TextInput from "@/components/TextInput";
 
 export default function NewsletterForm({
 	title = "Subscribe to my newsletter",
@@ -19,50 +17,83 @@ export default function NewsletterForm({
 		message: title,
 	});
 
-	const icon = isPending ? (
-		<IconLoader2 className="animate-spin" />
-	) : (
-		<IconMail />
-	);
-
 	return (
-		<div className="mx-auto max-w-lg rounded-3xl border border-zinc-400/50 bg-neutral-100/50 p-4 backdrop-blur-sm md:text-lg dark:border-zinc-600/50 dark:bg-neutral-900/50 print:hidden">
-			<span
-				className={clsx(
-					{
-						"text-red-600 dark:text-red-400": status === "error",
-					},
-					"font-semibold",
-				)}
+		<div className="print:hidden">
+			<p
+				style={{
+					fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+					fontSize: "11px",
+					fontWeight: "bold",
+					color: status === "error" ? "#cc0000" : "#000",
+					marginBottom: "6px",
+				}}
 			>
 				{message}
-			</span>
+			</p>
 
-			<form
-				className={clsx("mt-2 flex w-full flex-wrap justify-between gap-2", {
-					hidden: status === "success",
-				})}
-				action={formAction}
-			>
-				<TextInput
-					className="grow rounded-xl"
-					type="email"
-					id="email"
-					name="email"
-					placeholder="Enter your email..."
-					required
-					aria-label="Email address"
-					autoComplete="email"
-				/>
-
-				<button
-					className="box-border flex grow cursor-default flex-row items-center justify-center gap-2 rounded-xl border-t border-white/30 bg-linear-to-b from-teal-600 to-teal-800 px-4 py-2 font-semibold text-white drop-shadow-xs active:opacity-70 enabled:hover:from-teal-500 enabled:hover:to-teal-700 disabled:opacity-70 dark:from-teal-700 dark:to-teal-900 dark:enabled:hover:from-teal-600 dark:enabled:hover:to-teal-800"
-					disabled={isPending}
-					type="submit"
+			{status !== "success" && (
+				<form
+					action={formAction}
+					style={{
+						display: "flex",
+						flexWrap: "wrap",
+						gap: "4px",
+					}}
 				>
-					{icon} Subscribe
-				</button>
-			</form>
+					<input
+						type="email"
+						id="email"
+						name="email"
+						placeholder="Enter your email address..."
+						required
+						aria-label="Email address"
+						autoComplete="email"
+						style={{
+							flex: "1 1 180px",
+							background: "#fff",
+							borderTop: "2px solid #404040",
+							borderLeft: "2px solid #404040",
+							borderRight: "2px solid #ffffff",
+							borderBottom: "2px solid #ffffff",
+							boxShadow: "inset 1px 1px 0 #808080",
+							padding: "2px 6px",
+							fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+							fontSize: "11px",
+							color: "#000",
+							outline: "none",
+						}}
+					/>
+					<button
+						type="submit"
+						disabled={isPending}
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: "4px",
+							padding: "2px 10px",
+							background: "#d4d0c8",
+							borderTop: "2px solid #ffffff",
+							borderLeft: "2px solid #ffffff",
+							borderRight: "2px solid #404040",
+							borderBottom: "2px solid #404040",
+							boxShadow: "inset 1px 1px 0 #dfdfdf, inset -1px -1px 0 #808080",
+							fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+							fontSize: "11px",
+							color: "#000",
+							cursor: "default",
+							opacity: isPending ? 0.6 : 1,
+							whiteSpace: "nowrap",
+						}}
+					>
+						{isPending ? (
+							<IconLoader2 size={14} className="animate-spin" aria-hidden />
+						) : (
+							<IconMail size={14} aria-hidden />
+						)}
+						Subscribe
+					</button>
+				</form>
+			)}
 		</div>
 	);
 }

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -1,27 +1,229 @@
+"use client";
+
 import Link from "next/link";
-import ThemeSwitch from "./ThemeSwitch";
-import SidebarLinks from "@/components/SidebarLinks";
-import SocialIcons from "@/components/SocialIcons";
+import { links } from "@/lib/navData";
+import { usePathname } from "next/navigation";
 
 export default function Sidebar() {
-	return (
-		<nav className="z-50 hidden shrink-0 lg:block lg:w-72">
-			<div className="sticky top-20 flex flex-col">
-				<div className="flex flex-row items-center">
-					<Link
-						className="min-w-56 align-middle text-4xl font-bold transition-colors hover:text-zinc-600 dark:hover:text-zinc-400"
-						href="/"
-					>
-						Nick Oates
-					</Link>
+	const rawPathname = usePathname();
+	const pathname = rawPathname.startsWith("/blog") ? "/blog" : rawPathname;
 
-					<ThemeSwitch />
+	return (
+		<nav
+			className="z-50 hidden shrink-0 lg:block lg:w-64"
+			aria-label="Main navigation"
+		>
+			<div className="sticky top-8">
+				{/* Main window chrome */}
+				<div
+					style={{
+						background: "#d4d0c8",
+						borderTop: "2px solid #ffffff",
+						borderLeft: "2px solid #ffffff",
+						borderRight: "2px solid #404040",
+						borderBottom: "2px solid #404040",
+						boxShadow: "inset 1px 1px 0 #dfdfdf, inset -1px -1px 0 #808080",
+					}}
+				>
+					{/* Title bar */}
+					<div
+						style={{
+							background: "linear-gradient(to right, #0a246a, #a6caf0)",
+							padding: "3px 6px",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "space-between",
+						}}
+					>
+						<div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+							<span style={{ fontSize: "13px" }} aria-hidden>🖥️</span>
+							<span
+								style={{
+									fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+									fontSize: "11px",
+									fontWeight: "bold",
+									color: "#fff",
+									textShadow: "1px 1px 0 #00008b",
+									userSelect: "none",
+								}}
+							>
+								Nick Oates
+							</span>
+						</div>
+						<div style={{ display: "flex", gap: "2px" }}>
+							{["_", "□", "✕"].map((btn) => (
+								<div
+									key={btn}
+									aria-hidden
+									style={{
+										width: "16px",
+										height: "14px",
+										background: "#d4d0c8",
+										borderTop: "1px solid #ffffff",
+										borderLeft: "1px solid #ffffff",
+										borderRight: "1px solid #404040",
+										borderBottom: "1px solid #404040",
+										boxShadow: "inset 1px 1px 0 #dfdfdf, inset -1px -1px 0 #808080",
+										display: "flex",
+										alignItems: "center",
+										justifyContent: "center",
+										fontSize: "9px",
+										color: "#000",
+										cursor: "default",
+										userSelect: "none",
+										fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+									}}
+								>
+									{btn}
+								</div>
+							))}
+						</div>
+					</div>
+
+					{/* Profile section */}
+					<div
+						style={{
+							background: "#d4d0c8",
+							padding: "8px",
+							borderBottom: "1px solid #808080",
+							textAlign: "center",
+						}}
+					>
+						{/* eslint-disable-next-line @next/next/no-img-element */}
+						<img
+							src="/images/nick-oates.webp"
+							alt="Nick Oates"
+							width={64}
+							height={64}
+							style={{
+								borderTop: "2px solid #404040",
+								borderLeft: "2px solid #404040",
+								borderRight: "2px solid #ffffff",
+								borderBottom: "2px solid #ffffff",
+								boxShadow: "inset 1px 1px 0 #808080",
+								display: "block",
+								margin: "0 auto 4px",
+								objectFit: "cover",
+								borderRadius: "0",
+							}}
+						/>
+						<p
+							style={{
+								fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+								fontSize: "11px",
+								fontWeight: "bold",
+								color: "#000",
+							}}
+						>
+							Nick Oates
+						</p>
+						<p
+							style={{
+								fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+								fontSize: "10px",
+								color: "#444",
+							}}
+						>
+							Software Engineer
+						</p>
+					</div>
+
+					{/* Nav links */}
+					<div style={{ padding: "4px" }}>
+						{links.map((link) => {
+							const isActive = pathname === link.href;
+							return (
+								<Link
+									key={link.href}
+									href={link.href}
+									style={{
+										display: "flex",
+										alignItems: "center",
+										gap: "6px",
+										padding: "3px 6px",
+										textDecoration: "none",
+										fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+										fontSize: "11px",
+										color: isActive ? "#ffffff" : "#000000",
+										background: isActive ? "#0a246a" : "transparent",
+										borderTop: isActive ? "1px solid #0a246a" : "1px solid transparent",
+										userSelect: "none",
+									}}
+									className={!isActive ? "hover:bg-[#0a246a] hover:text-white" : ""}
+								>
+									<link.Icon size={16} aria-hidden />
+									{link.title}
+								</Link>
+							);
+						})}
+					</div>
+
+					{/* Status bar */}
+					<div
+						style={{
+							borderTop: "1px solid #808080",
+							padding: "2px 6px",
+							fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+							fontSize: "10px",
+							color: "#000",
+							background: "#d4d0c8",
+							display: "flex",
+							justifyContent: "space-between",
+						}}
+					>
+						<span>4 items</span>
+						<span>nickoates.com</span>
+					</div>
 				</div>
 
-				<SidebarLinks />
-
-				<div className="fixed bottom-20 flex w-72 flex-row justify-center gap-6">
-					<SocialIcons />
+				{/* Social links as taskbar-style buttons */}
+				<div
+					style={{
+						marginTop: "8px",
+						background: "#d4d0c8",
+						borderTop: "2px solid #ffffff",
+						borderLeft: "2px solid #ffffff",
+						borderRight: "2px solid #404040",
+						borderBottom: "2px solid #404040",
+						boxShadow: "inset 1px 1px 0 #dfdfdf, inset -1px -1px 0 #808080",
+						padding: "6px",
+						display: "flex",
+						gap: "4px",
+						flexWrap: "wrap",
+					}}
+				>
+					{[
+						{ label: "X (Twitter)", href: "https://x.com/nickoates_", symbol: "𝕏" },
+						{ label: "GitHub", href: "https://github.com/n1ckoates", symbol: "GH" },
+						{ label: "Email", href: "mailto:nick@nickoates.com", symbol: "✉" },
+					].map((s) => (
+						<a
+							key={s.href}
+							href={s.href}
+							target="_blank"
+							rel="noreferrer"
+							title={s.label}
+							style={{
+								display: "inline-flex",
+								alignItems: "center",
+								gap: "3px",
+								padding: "2px 8px",
+								background: "#d4d0c8",
+								borderTop: "2px solid #ffffff",
+								borderLeft: "2px solid #ffffff",
+								borderRight: "2px solid #404040",
+								borderBottom: "2px solid #404040",
+								boxShadow: "inset 1px 1px 0 #dfdfdf, inset -1px -1px 0 #808080",
+								textDecoration: "none",
+								fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+								fontSize: "11px",
+								color: "#000",
+								cursor: "default",
+							}}
+						>
+							<span aria-hidden>{s.symbol}</span> {s.label}
+						</a>
+					))}
 				</div>
 			</div>
 		</nav>

--- a/app/components/Win2kPostGrid.tsx
+++ b/app/components/Win2kPostGrid.tsx
@@ -1,0 +1,143 @@
+import Link from "next/link";
+import Image from "next/image";
+import { ViewTransition } from "react";
+import type { Post } from "@/lib/.content-collections/generated";
+
+interface Win2kPostGridProps {
+	posts: Post[];
+}
+
+export default function Win2kPostGrid({ posts }: Win2kPostGridProps) {
+	return (
+		<div
+			style={{
+				display: "grid",
+				gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+				gap: "8px",
+			}}
+		>
+			{posts.map((post) => (
+				<Link
+					key={post._meta.path}
+					href={"/blog/" + post._meta.path}
+					style={{ textDecoration: "none", display: "block" }}
+					aria-label={post.title}
+				>
+					{/* Each post is a little Win2k file icon panel */}
+					<div
+						style={{
+							background: "#d4d0c8",
+							borderTop: "2px solid #ffffff",
+							borderLeft: "2px solid #ffffff",
+							borderRight: "2px solid #404040",
+							borderBottom: "2px solid #404040",
+							boxShadow: "inset 1px 1px 0 #dfdfdf, inset -1px -1px 0 #808080",
+							overflow: "hidden",
+							cursor: "default",
+						}}
+						className="group"
+					>
+						{/* Mini titlebar */}
+						<div
+							style={{
+								background: "linear-gradient(to right, #0a246a, #a6caf0)",
+								padding: "2px 4px",
+								display: "flex",
+								alignItems: "center",
+								gap: "4px",
+							}}
+						>
+							<span style={{ fontSize: "10px" }} aria-hidden>📄</span>
+							<span
+								style={{
+									fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+									fontSize: "10px",
+									fontWeight: "bold",
+									color: "#fff",
+									overflow: "hidden",
+									textOverflow: "ellipsis",
+									whiteSpace: "nowrap",
+								}}
+							>
+								{post._meta.path}.html
+							</span>
+						</div>
+
+						{/* Image preview */}
+						<div
+							style={{
+								position: "relative",
+								height: "120px",
+								background: "#000",
+								borderBottom: "1px solid #808080",
+							}}
+						>
+							<Image
+								src={post.cover}
+								alt={post.coverAlt}
+								fill
+								className="object-cover"
+								sizes="(max-width: 768px) 100vw, 400px"
+								placeholder="blur"
+								blurDataURL={post.blurDataURL}
+								style={{ filter: "saturate(0.9) contrast(1.05)" }}
+							/>
+						</div>
+
+						{/* Post details */}
+						<div
+							style={{
+								padding: "6px 8px",
+								background: "#d4d0c8",
+							}}
+						>
+							<ViewTransition name={`${post._meta.path}-grid-title`}>
+								<p
+									style={{
+										fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+										fontSize: "11px",
+										fontWeight: "bold",
+										color: "#000",
+										marginBottom: "2px",
+										lineHeight: "1.3",
+									}}
+								>
+									{post.title}
+								</p>
+							</ViewTransition>
+							<ViewTransition name={`${post._meta.path}-grid-time`}>
+								<p
+									style={{
+										fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+										fontSize: "10px",
+										color: "#444",
+									}}
+								>
+									{post.date.toLocaleDateString(undefined, { dateStyle: "medium" })} &bull; {post.readingTime} min
+								</p>
+							</ViewTransition>
+							<div
+								style={{
+									marginTop: "6px",
+									display: "inline-block",
+									background: "#d4d0c8",
+									borderTop: "2px solid #ffffff",
+									borderLeft: "2px solid #ffffff",
+									borderRight: "2px solid #404040",
+									borderBottom: "2px solid #404040",
+									boxShadow: "inset 1px 1px 0 #dfdfdf, inset -1px -1px 0 #808080",
+									padding: "1px 8px",
+									fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+									fontSize: "11px",
+									color: "#000",
+								}}
+							>
+								Open
+							</div>
+						</div>
+					</div>
+				</Link>
+			))}
+		</div>
+	);
+}

--- a/app/components/Win2kWindow.tsx
+++ b/app/components/Win2kWindow.tsx
@@ -1,0 +1,152 @@
+import React from "react";
+import clsx from "clsx";
+
+interface Win2kWindowProps {
+	title: string;
+	icon?: string;
+	children: React.ReactNode;
+	className?: string;
+	headerAction?: React.ReactNode;
+}
+
+export default function Win2kWindow({
+	title,
+	icon,
+	children,
+	className,
+	headerAction,
+}: Win2kWindowProps) {
+	return (
+		<div
+			className={clsx("win-window", className)}
+			role="region"
+			aria-label={title}
+		>
+			{/* Title bar */}
+			<div className="win-titlebar flex items-center justify-between">
+				<div className="flex items-center gap-1">
+					{icon && (
+						<span style={{ fontSize: "13px", lineHeight: 1 }} aria-hidden>
+							{icon}
+						</span>
+					)}
+					<span
+						style={{
+							fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+							fontSize: "11px",
+							fontWeight: "bold",
+							color: "#fff",
+							textShadow: "1px 1px 0 #00008b",
+						}}
+					>
+						{title}
+					</span>
+				</div>
+
+				<div className="flex items-center gap-1">
+					{headerAction && (
+						<div style={{ marginRight: "6px" }}>{headerAction}</div>
+					)}
+					{/* Window chrome buttons */}
+					<WinButton aria-label="Minimize" title="Minimize">_</WinButton>
+					<WinButton aria-label="Maximize" title="Maximize">□</WinButton>
+					<WinButton aria-label="Close" title="Close" style={{ fontWeight: "bold" }}>✕</WinButton>
+				</div>
+			</div>
+
+			{/* Menu bar simulation */}
+			<div
+				style={{
+					background: "#d4d0c8",
+					borderBottom: "1px solid #808080",
+					padding: "2px 4px",
+					display: "flex",
+					gap: "2px",
+					fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+					fontSize: "11px",
+				}}
+			>
+				{["File", "Edit", "View", "Help"].map((item) => (
+					<span
+						key={item}
+						style={{
+							padding: "1px 6px",
+							cursor: "default",
+							color: "#000",
+						}}
+						className="hover:bg-[#0a246a] hover:text-white"
+					>
+						{item}
+					</span>
+				))}
+			</div>
+
+			{/* Content area */}
+			<div
+				style={{
+					background: "#ffffff",
+					margin: "4px",
+					padding: "8px",
+					border: "2px solid #404040",
+					borderRight: "2px solid #ffffff",
+					borderBottom: "2px solid #ffffff",
+					boxShadow: "inset 1px 1px 0 #808080",
+					minHeight: "40px",
+				}}
+			>
+				{children}
+			</div>
+
+			{/* Status bar */}
+			<div
+				style={{
+					background: "#d4d0c8",
+					borderTop: "1px solid #808080",
+					padding: "2px 8px",
+					display: "flex",
+					justifyContent: "space-between",
+					fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+					fontSize: "11px",
+					color: "#000",
+				}}
+			>
+				<span>Ready</span>
+				<span style={{ borderLeft: "1px solid #808080", paddingLeft: "8px" }}>nickoates.com</span>
+			</div>
+		</div>
+	);
+}
+
+function WinButton({
+	children,
+	...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+	return (
+		<button
+			type="button"
+			style={{
+				width: "16px",
+				height: "14px",
+				background: "#d4d0c8",
+				borderTop: "1px solid #ffffff",
+				borderLeft: "1px solid #ffffff",
+				borderRight: "1px solid #404040",
+				borderBottom: "1px solid #404040",
+				boxShadow: "inset 1px 1px 0 #dfdfdf, inset -1px -1px 0 #808080",
+				color: "#000",
+				fontSize: "9px",
+				lineHeight: 1,
+				cursor: "default",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+				userSelect: "none",
+				flexShrink: 0,
+			}}
+			{...props}
+		>
+			{children}
+		</button>
+	);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -11,6 +11,22 @@
 	::file-selector-button {
 		border-color: var(--color-gray-200, currentColor);
 	}
+
+	:root {
+		--win-bg: #008080;
+		--win-silver: #d4d0c8;
+		--win-dark: #0a246a;
+		--win-title-start: #0a246a;
+		--win-title-end: #a6caf0;
+		--win-border-light: #ffffff;
+		--win-border-mid: #808080;
+		--win-border-dark: #404040;
+		--win-button-face: #d4d0c8;
+		--win-text: #000000;
+		--win-window-bg: #ffffff;
+		--win-selected: #0a246a;
+		--win-selected-text: #ffffff;
+	}
 }
 
 @utility bg-grid {
@@ -19,4 +35,85 @@
 		linear-gradient(to right, currentColor 1px, transparent 1px),
 		linear-gradient(to bottom, currentColor 1px, transparent 1px);
 	background-attachment: fixed;
+}
+
+/* Win2000 beveled border utilities */
+@utility win-raised {
+	border-top: 2px solid #ffffff;
+	border-left: 2px solid #ffffff;
+	border-right: 2px solid #404040;
+	border-bottom: 2px solid #404040;
+	box-shadow: inset 1px 1px 0px #dfdfdf, inset -1px -1px 0px #808080;
+}
+
+@utility win-sunken {
+	border-top: 2px solid #404040;
+	border-left: 2px solid #404040;
+	border-right: 2px solid #ffffff;
+	border-bottom: 2px solid #ffffff;
+	box-shadow: inset 1px 1px 0px #808080, inset -1px -1px 0px #dfdfdf;
+}
+
+@utility win-button {
+	background-color: #d4d0c8;
+	border-top: 2px solid #ffffff;
+	border-left: 2px solid #ffffff;
+	border-right: 2px solid #404040;
+	border-bottom: 2px solid #404040;
+	box-shadow: inset 1px 1px 0px #dfdfdf, inset -1px -1px 0px #808080;
+	color: #000000;
+	padding: 2px 8px;
+	cursor: default;
+	font-family: "MS Sans Serif", "Tahoma", sans-serif;
+	font-size: 11px;
+	user-select: none;
+}
+
+@utility win-button-active {
+	border-top: 2px solid #404040;
+	border-left: 2px solid #404040;
+	border-right: 2px solid #ffffff;
+	border-bottom: 2px solid #ffffff;
+	box-shadow: inset 1px 1px 0px #808080, inset -1px -1px 0px #dfdfdf;
+	padding: 3px 7px 1px 9px;
+}
+
+@utility win-input {
+	background-color: #ffffff;
+	border-top: 2px solid #404040;
+	border-left: 2px solid #404040;
+	border-right: 2px solid #ffffff;
+	border-bottom: 2px solid #ffffff;
+	box-shadow: inset 1px 1px 0px #808080;
+	color: #000000;
+	font-family: "MS Sans Serif", "Tahoma", sans-serif;
+	font-size: 11px;
+	padding: 2px 4px;
+}
+
+@utility win-titlebar {
+	background: linear-gradient(to right, #0a246a, #a6caf0);
+	color: #ffffff;
+	font-family: "MS Sans Serif", "Tahoma", sans-serif;
+	font-size: 11px;
+	font-weight: bold;
+	padding: 3px 5px;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	user-select: none;
+}
+
+@utility win-window {
+	background-color: #d4d0c8;
+	border-top: 2px solid #ffffff;
+	border-left: 2px solid #ffffff;
+	border-right: 2px solid #404040;
+	border-bottom: 2px solid #404040;
+	box-shadow: inset 1px 1px 0px #dfdfdf, inset -1px -1px 0px #808080;
+}
+
+@utility win-font {
+	font-family: "MS Sans Serif", "Tahoma", "Arial", sans-serif;
+	font-size: 11px;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import "./globals.css";
-import { Mona_Sans } from "next/font/google";
 import Navbar from "@/components/Navbar";
 import Sidebar from "@/components/Sidebar";
 import { Analytics } from "@vercel/analytics/react";
@@ -11,13 +10,9 @@ export const metadata = mergeMetadata();
 
 export const viewport = {
 	themeColor: [
-		{ media: "(prefers-color-scheme: light)", color: "#fafafa" },
-		{ media: "(prefers-color-scheme: dark)", color: "#09090b" },
-		{ color: "#2563eb" },
+		{ color: "#008080" },
 	],
 };
-
-const monaSans = Mona_Sans({ subsets: ["latin"] });
 
 export default function RootLayout({
 	children,
@@ -28,16 +23,29 @@ export default function RootLayout({
 		<html
 			lang="en"
 			suppressHydrationWarning
-			className={`${monaSans.className} scroll-smooth [scrollbar-gutter:stable]`}
+			className="scroll-smooth [scrollbar-gutter:stable]"
 		>
-			<body className="max-w-7xl gap-8 bg-zinc-50 px-6 pb-8 text-black lg:mx-auto lg:flex lg:flex-row lg:py-20 2xl:px-0 dark:bg-zinc-950 dark:text-white">
-				<div className="bg-grid fixed top-0 left-0 -z-50 size-full [mask-image:radial-gradient(ellipse_at_top_left,black,transparent_50%)] text-zinc-200 dark:text-zinc-900" />
+			<body
+				className="max-w-7xl gap-8 px-6 pb-8 text-black lg:mx-auto lg:flex lg:flex-row lg:py-8 2xl:px-0"
+				style={{
+					background: "#008080",
+					fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+					fontSize: "11px",
+				}}
+			>
+				{/* Tiled desktop wallpaper pattern */}
+				<div
+					className="fixed top-0 left-0 -z-50 size-full"
+					style={{
+						background: "#008080",
+						backgroundImage: `url("data:image/svg+xml,%3Csvg width='4' height='4' viewBox='0 0 4 4' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='0' y='0' width='2' height='2' fill='%23007070' opacity='0.5'/%3E%3C/svg%3E")`,
+						backgroundSize: "4px 4px",
+					}}
+				/>
 
 				<ThemeProvider attribute="class" disableTransitionOnChange>
 					<Navbar />
-
 					<Sidebar />
-
 					<main id="main" className="mt-16 grow lg:mt-0">
 						{children}
 					</main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,119 +1,75 @@
 import Link from "next/link";
-import { IconArrowRight } from "@tabler/icons-react";
 import NewsletterForm from "@/components/NewsletterForm";
-import { OrbContainer, Orb } from "@/components/Orb";
 import allPosts from "@/lib/posts";
 import Image from "next/image";
-import { S } from "@/components/typography";
-import { Prose } from "@/components/Prose";
 import { ViewTransition } from "react";
+import Win2kWindow from "@/components/Win2kWindow";
+import Win2kPostGrid from "@/components/Win2kPostGrid";
 
 export default function Page() {
 	return (
 		<>
 			<h1 className="sr-only">Nick Oates - Software Engineer</h1>
 
-			<OrbContainer>
-				<Orb className="right-0 bg-blue-400/30 dark:bg-blue-600/30" />
-				<Orb className="top-28 right-36 bg-purple-400/30 dark:bg-purple-600/30" />
-			</OrbContainer>
-
-			<ViewTransition name="about-lead">
-				<Prose as="p">
-					Hey, I&apos;m <S>Nick Oates</S>, a software engineer with a passion for designing and building cool things on the web. I love obsessing over the small details of my work, and I&apos;m always looking for new things to learn and ways to improve my skills. <Link href="/about" className="whitespace-nowrap">Read more&hellip;</Link>
-				</Prose>
-			</ViewTransition>
-
-			<div className="my-4 flex items-center justify-between">
-				<ViewTransition name="blog-posts-header">
-					<h2 className="text-2xl font-bold">Blog Posts</h2>
+			{/* About window */}
+			<Win2kWindow
+				title="About Nick Oates"
+				icon="👤"
+				className="mb-3"
+			>
+				<ViewTransition name="about-lead">
+					<p style={{ fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif', fontSize: "11px", lineHeight: "1.5", color: "#000" }}>
+						Hey, I&apos;m{" "}
+						<strong style={{ color: "#0a246a" }}>Nick Oates</strong>, a software
+						engineer with a passion for designing and building cool things on the
+						web. I love obsessing over the small details of my work, and I&apos;m
+						always looking for new things to learn and ways to improve my
+						skills.{" "}
+						<Link
+							href="/about"
+							className="whitespace-nowrap"
+							style={{ color: "#0000ee", textDecoration: "underline" }}
+						>
+							Read more&hellip;
+						</Link>
+					</p>
 				</ViewTransition>
+			</Win2kWindow>
 
-				<Link
-					href="/blog"
-					className="group flex items-center gap-1 text-zinc-700 transition-colors hover:text-zinc-600 dark:text-zinc-300 dark:hover:text-zinc-400"
-				>
-					View All
-					<IconArrowRight
-						size={20}
-						className="transition-transform group-hover:translate-x-0.5"
-					/>
-				</Link>
-			</div>
-
-			<PostGrid />
-
-			<OrbContainer>
-				<Orb className="bg-emerald-400/30 dark:bg-emerald-600/30" />
-				<Orb className="top-16 left-72 bg-cyan-400/30 dark:bg-cyan-600/30" />
-			</OrbContainer>
-
-			<h2 className="my-4 text-2xl font-bold">Newsletter</h2>
-			<p className="mx-auto my-4 max-w-2xl text-xl">
-				Occasionally, I send out a newsletter to share my thoughts about the
-				latest tech news and other things I find interesting &mdash; I
-				won&apos;t spam you, promise!
-			</p>
-			<NewsletterForm />
-		</>
-	);
-}
-
-function PostGrid() {
-	const posts = allPosts.slice(0, 2);
-
-	return (
-		<div className="mx-auto grid grid-cols-2 gap-4 md:grid-cols-3">
-			{posts.map((post) => (
-				<Link
-					href={"/blog/" + post._meta.path}
-					className="group relative h-60 overflow-hidden rounded-xl first:col-span-2 only:col-span-full last:nth-4:col-span-2 max-md:last:even:col-span-full md:h-80 md:last:nth-3:col-span-full"
-					aria-label={post.title}
-					key={post._meta.path}
-				>
-					<Image
-						src={post.cover}
-						alt={post.coverAlt}
-						fill
-						className="object-cover transition group-hover:scale-105"
-						sizes="(max-width: 896px) 100vw, 896px"
-						priority
-						placeholder="blur"
-						blurDataURL={post.blurDataURL}
-					/>
-
-
-					<div className="absolute w-full bg-linear-to-b from-zinc-50/70 via-zinc-50/50 via-75% p-4 dark:from-zinc-950/70 dark:via-zinc-950/50">
-						<ViewTransition name={`${post._meta.path}-grid-time`}>
-							<p
-								className="text-zinc-800 drop-shadow-xs dark:text-zinc-200"
-							>
-								{post.date.toLocaleDateString(undefined, {
-									dateStyle: "long",
-								})}{" "}
-								&bull; {post.readingTime} min read
-							</p>
-						</ViewTransition>
-
-
-						<ViewTransition name={`${post._meta.path}-grid-title`}>
-							<h1
-								className="max-w-lg text-2xl font-bold text-balance drop-shadow-xs md:group-first:text-3xl"
-							>
-								{post.title}
-							</h1>
-						</ViewTransition>
-					</div>
-
-					{/* This is a <div> instead of a <Link> because the card itself is a Link */}
-					<div
-						className="absolute bottom-4 left-4 rounded-lg bg-zinc-300/40 px-4 py-2 text-sm font-medium backdrop-blur-sm transition hover:bg-zinc-400/60 md:text-base dark:bg-zinc-700/40 dark:hover:bg-zinc-600/60"
-						aria-hidden
+			{/* Blog Posts window */}
+			<Win2kWindow
+				title="Blog Posts"
+				icon="📰"
+				className="mb-3"
+				headerAction={
+					<Link
+						href="/blog"
+						style={{
+							fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif',
+							fontSize: "11px",
+							color: "#0000ee",
+							textDecoration: "underline",
+						}}
 					>
-						Read post
-					</div>
-				</Link>
-			))}
-		</div>
+						View All &rarr;
+					</Link>
+				}
+			>
+				<Win2kPostGrid posts={allPosts.slice(0, 2)} />
+			</Win2kWindow>
+
+			{/* Newsletter window */}
+			<Win2kWindow
+				title="Newsletter"
+				icon="✉️"
+			>
+				<p style={{ fontFamily: '"MS Sans Serif", Tahoma, Arial, sans-serif', fontSize: "11px", marginBottom: "8px", color: "#000" }}>
+					Occasionally, I send out a newsletter to share my thoughts about the
+					latest tech news and other things I find interesting &mdash; I
+					won&apos;t spam you, promise!
+				</p>
+				<NewsletterForm />
+			</Win2kWindow>
+		</>
 	);
 }


### PR DESCRIPTION
## Windows 2000 Redesign 🪟

This PR redesigns the homepage (and supporting components) to look like a Microsoft Windows 2000 UI.

### Changes

- **`app/globals.css`** — Added Win2k CSS utilities: `win-raised`, `win-sunken`, `win-button`, `win-input`, `win-titlebar`, `win-window`, `win-font` using authentic beveled borders and the classic `#d4d0c8` silver palette.
- **`app/layout.tsx`** — Replaced modern font/colors with teal `#008080` desktop background, Tahoma/MS Sans Serif system font stack, and removed dark mode theming.
- **`app/page.tsx`** — Rewrote homepage to use `Win2kWindow` panels for About, Blog Posts, and Newsletter sections.
- **`app/components/Win2kWindow.tsx`** — New component rendering a full Win2k window with gradient title bar, window chrome buttons (_/□/✕), a simulated menu bar (File/Edit/View/Help), inset content area, and status bar.
- **`app/components/Win2kPostGrid.tsx`** — New component rendering blog post cards as Win2k file/document panels with mini title bars and beveled "Open" buttons.
- **`app/components/Sidebar.tsx`** — Rewritten as a Win2k Explorer-style navigation panel with profile photo, beveled nav links, and social buttons.
- **`app/components/Navbar.tsx`** — Rewritten as a Win2k taskbar with a "Start" button that opens a Start Menu popup with the site navigation.
- **`app/components/NewsletterForm.tsx`** — Restyled to use Win2k beveled input and button chrome.